### PR TITLE
Fixed double Conversation input (#109)

### DIFF
--- a/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
+++ b/patches/net/minecraft/network/NetHandlerPlayServer.java.patch
@@ -907,7 +907,7 @@
          {
              TextComponentTranslation textcomponenttranslation = new TextComponentTranslation("chat.cannotSend", new Object[0]);
              textcomponenttranslation.getStyle().setColor(TextFormatting.RED);
-@@ -931,47 +1415,277 @@
+@@ -931,47 +1415,276 @@
              {
                  if (!ChatAllowedCharacters.isAllowedCharacter(s.charAt(i)))
                  {
@@ -957,7 +957,6 @@
 +            } else if (s.isEmpty()) {
 +                LOGGER.warn(this.player.getName() + " tried to send an empty message");
 +            } else if (getPlayer().isConversing()) {
-+                getPlayer().acceptConversationInput(s);
 +                // Spigot start
 +                final String message = s;
 +                this.serverController.processQueue.add(new Waitable()
@@ -1197,7 +1196,7 @@
          this.player.markPlayerActive();
  
          switch (packetIn.getAction())
-@@ -1053,8 +1767,16 @@
+@@ -1053,8 +1766,16 @@
      public void processUseEntity(CPacketUseEntity packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1214,7 +1213,7 @@
          this.player.markPlayerActive();
  
          if (entity != null)
-@@ -1069,20 +1791,58 @@
+@@ -1069,20 +1790,58 @@
  
              if (this.player.getDistanceSq(entity) < d0)
              {
@@ -1274,7 +1273,7 @@
                      {
                          this.disconnect(new TextComponentTranslation("multiplayer.disconnect.invalid_entity_attacked", new Object[0]));
                          this.serverController.logWarning("Player " + this.player.getName() + " tried to attack an invalid entity");
-@@ -1090,6 +1850,10 @@
+@@ -1090,6 +1849,10 @@
                      }
  
                      this.player.attackTargetEntityWithCurrentItem(entity);
@@ -1285,7 +1284,7 @@
                  }
              }
          }
-@@ -1108,7 +1872,8 @@
+@@ -1108,7 +1871,8 @@
                  if (this.player.queuedEndExit)
                  {
                      this.player.queuedEndExit = false;
@@ -1295,7 +1294,7 @@
                      CriteriaTriggers.CHANGED_DIMENSION.trigger(this.player, DimensionType.THE_END, DimensionType.OVERWORLD);
                  }
                  else
-@@ -1136,17 +1901,21 @@
+@@ -1136,17 +1900,21 @@
      public void processCloseWindow(CPacketCloseWindow packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1319,7 +1318,7 @@
              {
                  NonNullList<ItemStack> nonnulllist = NonNullList.<ItemStack>create();
  
-@@ -1159,9 +1928,296 @@
+@@ -1159,9 +1927,296 @@
              }
              else
              {
@@ -1618,7 +1617,7 @@
                  {
                      this.player.connection.sendPacket(new SPacketConfirmTransaction(packetIn.getWindowId(), packetIn.getActionNumber(), true));
                      this.player.isChangingQuantityOnly = true;
-@@ -1178,8 +2234,8 @@
+@@ -1178,8 +2233,8 @@
  
                      for (int j = 0; j < this.player.openContainer.inventorySlots.size(); ++j)
                      {
@@ -1629,7 +1628,7 @@
                          nonnulllist1.add(itemstack1);
                      }
  
-@@ -1203,6 +2259,7 @@
+@@ -1203,6 +2258,7 @@
      public void processEnchantItem(CPacketEnchantItem packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1637,7 +1636,7 @@
          this.player.markPlayerActive();
  
          if (this.player.openContainer.windowId == packetIn.getWindowId() && this.player.openContainer.getCanCraft(this.player) && !this.player.isSpectator())
-@@ -1242,8 +2299,47 @@
+@@ -1242,8 +2298,47 @@
              }
  
              boolean flag1 = packetIn.getSlotId() >= 1 && packetIn.getSlotId() <= 45;
@@ -1686,7 +1685,7 @@
              if (flag1 && flag2)
              {
                  if (itemstack.isEmpty())
-@@ -1273,6 +2369,7 @@
+@@ -1273,6 +2368,7 @@
      public void processConfirmTransaction(CPacketConfirmTransaction packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1694,7 +1693,7 @@
          Short oshort = this.pendingTransactions.lookup(this.player.openContainer.windowId);
  
          if (oshort != null && packetIn.getUid() == oshort.shortValue() && this.player.openContainer.windowId == packetIn.getWindowId() && !this.player.openContainer.getCanCraft(this.player) && !this.player.isSpectator())
-@@ -1284,6 +2381,7 @@
+@@ -1284,6 +2380,7 @@
      public void processUpdateSign(CPacketUpdateSign packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1702,7 +1701,7 @@
          this.player.markPlayerActive();
          WorldServer worldserver = this.serverController.getWorld(this.player.dimension);
          BlockPos blockpos = packetIn.getPosition();
-@@ -1300,19 +2398,35 @@
+@@ -1300,19 +2397,35 @@
  
              TileEntitySign tileentitysign = (TileEntitySign)tileentity;
  
@@ -1740,7 +1739,7 @@
              tileentitysign.markDirty();
              worldserver.notifyBlockUpdate(blockpos, iblockstate, iblockstate, 3);
          }
-@@ -1320,6 +2434,7 @@
+@@ -1320,6 +2433,7 @@
  
      public void processKeepAlive(CPacketKeepAlive packetIn)
      {
@@ -1748,7 +1747,7 @@
          if (this.field_194403_g && packetIn.getKey() == this.field_194404_h)
          {
              int i = (int)(this.currentTimeMillis() - this.field_194402_f);
-@@ -1328,7 +2443,11 @@
+@@ -1328,7 +2442,11 @@
          }
          else if (!this.player.getName().equals(this.serverController.getServerOwner()))
          {
@@ -1761,7 +1760,7 @@
          }
      }
  
-@@ -1340,20 +2459,28 @@
+@@ -1340,20 +2458,28 @@
      public void processPlayerAbilities(CPacketPlayerAbilities packetIn)
      {
          PacketThreadUtil.checkThreadAndEnqueue(packetIn, this, this.player.getServerWorld());
@@ -1797,7 +1796,7 @@
      }
  
      public void processClientSettings(CPacketClientSettings packetIn)
-@@ -1369,6 +2496,11 @@
+@@ -1369,6 +2495,11 @@
  
          if ("MC|BEdit".equals(s))
          {
@@ -1809,7 +1808,7 @@
              PacketBuffer packetbuffer = packetIn.getBufferData();
  
              try
-@@ -1395,15 +2527,22 @@
+@@ -1395,15 +2526,22 @@
                  if (itemstack.getItem() == Items.WRITABLE_BOOK && itemstack.getItem() == itemstack1.getItem())
                  {
                      itemstack1.setTagInfo("pages", itemstack.getTagCompound().getTagList("pages", 8));
@@ -1832,7 +1831,7 @@
              PacketBuffer packetbuffer1 = packetIn.getBufferData();
  
              try
-@@ -1443,12 +2582,14 @@
+@@ -1443,12 +2581,14 @@
                      }
  
                      itemstack2.setTagInfo("pages", nbttaglist);
@@ -1848,7 +1847,7 @@
              }
          }
          else if ("MC|TrSel".equals(s))
-@@ -1466,6 +2607,7 @@
+@@ -1466,6 +2606,7 @@
              catch (Exception exception5)
              {
                  LOGGER.error("Couldn't select trade", (Throwable)exception5);
@@ -1856,7 +1855,7 @@
              }
          }
          else if ("MC|AdvCmd".equals(s))
-@@ -1528,6 +2670,7 @@
+@@ -1528,6 +2669,7 @@
              catch (Exception exception4)
              {
                  LOGGER.error("Couldn't set command block", (Throwable)exception4);
@@ -1864,7 +1863,7 @@
              }
          }
          else if ("MC|AutoCmd".equals(s))
-@@ -1606,6 +2749,7 @@
+@@ -1606,6 +2748,7 @@
              catch (Exception exception3)
              {
                  LOGGER.error("Couldn't set command block", (Throwable)exception3);
@@ -1872,7 +1871,7 @@
              }
          }
          else if ("MC|Beacon".equals(s))
-@@ -1632,6 +2776,7 @@
+@@ -1632,6 +2775,7 @@
                  catch (Exception exception2)
                  {
                      LOGGER.error("Couldn't set beacon", (Throwable)exception2);
@@ -1880,7 +1879,7 @@
                  }
              }
          }
-@@ -1743,6 +2888,7 @@
+@@ -1743,6 +2887,7 @@
              catch (Exception exception1)
              {
                  LOGGER.error("Couldn't set structure block", (Throwable)exception1);
@@ -1888,7 +1887,7 @@
              }
          }
          else if ("MC|PickItem".equals(s))
-@@ -1760,7 +2906,43 @@
+@@ -1760,7 +2905,43 @@
              catch (Exception exception)
              {
                  LOGGER.error("Couldn't pick item", (Throwable)exception);


### PR DESCRIPTION
There was two calls for accepting input which duplicated conversation inputs. Removed the one which wasn't the same as the patch in Spigot.