### PR TITLE
Migration from deprecated libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,11 @@ sourceSets {
     main.java.srcDir 'projects/Magma/src/main/java/'
     test.java.srcDir 'src/test/java/'
 }
-
+compileJava {
+    options.fork = true
+    options.forkOptions.executable = 'javac'
+    options.compilerArgs << "-XDignore.symbol.file"
+}
 
 minecraft {
     version = "1.12.2"

--- a/src/main/java/org/magmafoundation/magma/remapper/proxy/ProxyClass.java
+++ b/src/main/java/org/magmafoundation/magma/remapper/proxy/ProxyClass.java
@@ -16,7 +16,7 @@ import org.magmafoundation.magma.remapper.utils.RemappingUtils;
 public class ProxyClass {
 
     public static Class<?> forName(String className) throws ClassNotFoundException {
-        return forName(className, true, RemappingUtils.getCallerClassLoder());
+        return forName(className, true, RemappingUtils.getCallerClassLoader());
     }
 
     public static Class<?> forName(String className, boolean initialize, ClassLoader loader) throws ClassNotFoundException {

--- a/src/main/java/org/magmafoundation/magma/remapper/utils/RemappingUtils.java
+++ b/src/main/java/org/magmafoundation/magma/remapper/utils/RemappingUtils.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import jdk.internal.reflect.Reflection;
 import net.md_5.specialsource.transformer.MavenShade;
 import org.bukkit.plugin.PluginDescriptionFile;
 import org.magmafoundation.magma.Magma;
@@ -21,7 +23,7 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.commons.ClassRemapper;
 import org.objectweb.asm.commons.Remapper;
 import org.objectweb.asm.tree.ClassNode;
-import sun.reflect.Reflection;
+
 
 /**
  * RemappingUtils
@@ -149,7 +151,7 @@ public class RemappingUtils {
     }
 
     public static ClassLoader getCallerClassLoder() {
-        return Reflection.getCallerClass(3).getClassLoader();
+        return Reflection.getCallerClass().getClassLoader();
     }
 
     public static String inverseMapName(Class clazz) {

--- a/src/main/java/org/magmafoundation/magma/remapper/utils/RemappingUtils.java
+++ b/src/main/java/org/magmafoundation/magma/remapper/utils/RemappingUtils.java
@@ -150,7 +150,7 @@ public class RemappingUtils {
         return jarMapping.fastReverseMapFieldName(type, fieldName);
     }
 
-    public static ClassLoader getCallerClassLoder() {
+    public static ClassLoader getCallerClassLoader() {
         return Reflection.getCallerClass().getClassLoader();
     }
 


### PR DESCRIPTION
- Removed sun.reflect import, because its been deprecated and has been removed from java 8, on my machine it even refuses to build, because of that library.
- Fixed some typo issue
