### PR TITLE
stop forcing fire blockstate updates

### DIFF
--- a/patches/net/minecraft/block/BlockFire.java.patch
+++ b/patches/net/minecraft/block/BlockFire.java.patch
@@ -99,7 +99,7 @@
 +                                            server.getPluginManager().callEvent(spreadEvent);
 +
 +                                            if (!spreadEvent.isCancelled()) {
-+                                                blockState.update(true);
++                                                blockState.update(false);
 +                                            }
 +                                        }
 +                                        // CraftBukkit end


### PR DESCRIPTION
Don't force blockstate updates.

Was getting this stacktrace with it set to true:
```java
java.lang.IllegalArgumentException: Cannot set property PropertyInteger{name=age, clazz=class java.lang.Integer, values=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]} to 28 on block minecraft:fire, it is not an allowed value
at net.minecraft.block.state.BlockStateContainer$StateImplementation.func_177226_a(BlockStateContainer.java:227)
at net.minecraft.block.BlockFire.func_176203_a(BlockFire.java:526)
at org.bukkit.craftbukkit.v1_12_R1.block.CraftBlockState.update(CraftBlockState.java:190)
at org.bukkit.craftbukkit.v1_12_R1.block.CraftBlockState.update(CraftBlockState.java:174)
at net.minecraft.block.BlockFire.func_180650_b(BlockFire.java:254)
at net.minecraft.world.WorldServer.func_72955_a(WorldServer.java:975)
at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:423)
at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:961)
at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:456)
at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:851)
at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:723)
at java.lang.Thread.run(Thread.java:748)
```
Tested, Bukkit can still cancel the events, and firespread still works.