### PR TITLE
Fix Profession Lookup

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+
 import net.minecraft.entity.passive.EntityVillager;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
@@ -43,11 +43,10 @@ public class CraftVillager extends CraftAgeable implements Villager, InventoryHo
     }
 
     public Profession getProfession() {
-        if(getHandle().getProfession() < 7) {
-            return Profession.values()[getHandle().getProfession() + 1]; // Offset by 1 from the zombie types
-        }
+        Validate.isTrue(getHandle().getProfession() < Profession.HUSK.ordinal(),
+            "Invalid profession ID. Must be within range: " + Profession.NORMAL.ordinal() + "-" + Profession.HUSK.ordinal() + "!");
 
-        return Profession.values()[getHandle().getProfession()]; // Do not offset as it is a zombie type.
+        return Profession.values()[getHandle().getProfession() + 1]; // Offset by 1 from the zombie types
     }
 
     public void setProfession(Profession profession) {

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
@@ -2,12 +2,9 @@ package org.bukkit.craftbukkit.v1_12_R1.entity;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
-
 import net.minecraft.entity.passive.EntityVillager;
-import net.minecraft.util.registry.IRegistry;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftInventory;

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/entity/CraftVillager.java
@@ -2,10 +2,12 @@ package org.bukkit.craftbukkit.v1_12_R1.entity;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import javax.annotation.Nullable;
 
 import net.minecraft.entity.passive.EntityVillager;
+import net.minecraft.util.registry.IRegistry;
 import org.apache.commons.lang3.Validate;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
 import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftInventory;
@@ -41,7 +43,11 @@ public class CraftVillager extends CraftAgeable implements Villager, InventoryHo
     }
 
     public Profession getProfession() {
-        return Profession.values()[getHandle().getProfession() + 1]; // Offset by 1 from the zombie types
+        if(getHandle().getProfession() < 7) {
+            return Profession.values()[getHandle().getProfession() + 1]; // Offset by 1 from the zombie types
+        }
+
+        return Profession.values()[getHandle().getProfession()]; // Do not offset as it is a zombie type.
     }
 
     public void setProfession(Profession profession) {


### PR DESCRIPTION
This is to correct the issue found in this bug: https://github.com/magmafoundation/Magma/issues/226. 

Instead of it printing the error for it being out of array it will validate to ensure the given id is within the boundaries of the profession enum. 

