### PR TITLE
Add reload confirmation if mods are installed

### DIFF
--- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
+import org.magmafoundation.magma.api.ServerAPI;
 
 public class ReloadCommand extends BukkitCommand {
     public ReloadCommand(String name) {
@@ -21,7 +22,11 @@ public class ReloadCommand extends BukkitCommand {
     @Override
     public boolean execute(CommandSender sender, String currentAlias, String[] args) {
         if (!testPermission(sender)) return true;
-
+        if (ServerAPI.getModSize() > 0 && !(args.length > 4 && args[0].equalsIgnoreCase("confirm"))) {
+        	Command.broadcastCommandMessage(sender, ChatColor.RED + "The /reload command is not supported if mods are installed.");
+        	Command.broadcastCommandMessage(sender, ChatColor.RED + "Please use '/reload confirm' if you want to force reload the server.");
+        	return true;
+        }
         Command.broadcastCommandMessage(sender, ChatColor.RED + "Please note that this command is not supported and may cause issues when using some plugins.");
         Command.broadcastCommandMessage(sender, ChatColor.RED + "If you encounter any issues please use the /stop command to restart your server.");
         Bukkit.reload();


### PR DESCRIPTION
This commit makes it so that you have to type "/reload confirm" instead of "/reload" if mods are installed since it can break many mods.