### PR TITLE
Fix a NPE with the plugin class loader

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -20,6 +20,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
 import org.magmafoundation.magma.Magma;
 import org.magmafoundation.magma.patcher.Patcher;
 import org.magmafoundation.magma.remapper.ClassLoaderContext;
+import org.magmafoundation.magma.remapper.mappingsModel.ClassMappings;
 import org.magmafoundation.magma.remapper.utils.RemappingUtils;
 
 /**
@@ -99,8 +100,11 @@ public final class PluginClassLoader extends URLClassLoader {
         Class<?> result;
         try {
             if (name.startsWith("net.minecraft.server." + Magma.getBukkitVersion())) {
-                String remappedClass = RemappingUtils.jarMapping.byNMSName.get(name).getMcpName();
-                return Class.forName(remappedClass);
+                ClassMappings remappedClass = RemappingUtils.jarMapping.byNMSName.get(name);
+                if (remappedClass == null) {
+                    throw new ClassNotFoundException(name);
+                }
+                return Class.forName(remappedClass.getMcpName());
             }
 
             if (name.startsWith("org.bukkit.")) {


### PR DESCRIPTION
Hello,
This PR corrects an inconsistency in the class loader for plugins. Consider this code used to manage [scoreboards with packets](https://github.com/MrMicky-FR/FastBoard/blob/master/src/main/java/fr/mrmicky/fastboard/FastReflection.java) between versions:
```java
@EventHandler
public void onJoin(PlayerJoinEvent event) {
    try {
        Class.forName("net.minecraft.server.v1_12_R1.ScoreboardServer$Action");
        event.getPlayer().sendMessage("The class is present.");
    } catch (ClassNotFoundException e) {
        event.getPlayer().sendMessage("The class is not present: " + e.getMessage());
    }
}
```
Currently, this code throws a NullPointerException because no mapping is found for a class that does not exist. As a workaround, the NPE should also be intercepted here.
