### PR TITLE
Changeable FML kick messages

### DIFF
--- a/patches/net/minecraftforge/fml/common/FMLCommonHandler.java.patch
+++ b/patches/net/minecraftforge/fml/common/FMLCommonHandler.java.patch
@@ -16,7 +16,16 @@
  import net.minecraftforge.common.ForgeVersion;
  import net.minecraftforge.common.MinecraftForge;
  import net.minecraftforge.common.util.CompoundDataFixer;
-@@ -385,6 +387,10 @@
+@@ -83,6 +85,8 @@
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.MapMaker;
+ import com.google.common.collect.Maps;
++import org.bukkit.ChatColor;
++import org.magmafoundation.magma.configuration.MagmaConfig;
+ 
+ import javax.annotation.Nullable;
+ 
+@@ -385,6 +389,10 @@
  
      public void handleWorldDataSave(SaveHandler handler, WorldInfo worldInfo, NBTTagCompound tagCompound)
      {
@@ -27,7 +36,7 @@
          for (ModContainer mc : Loader.instance().getModList())
          {
              if (mc instanceof InjectedModContainer)
-@@ -405,7 +411,7 @@
+@@ -405,7 +413,7 @@
          {
              return;
          }
@@ -36,7 +45,7 @@
          {
              return;
          }
-@@ -507,7 +513,7 @@
+@@ -507,7 +515,7 @@
          MinecraftServer server = getMinecraftServerInstance();
          Loader.instance().serverStopped();
          // FORCE the internal server to stop: hello optifine workaround!
@@ -45,3 +54,12 @@
  
          // allow any pending exit to continue, clear exitLatch
          CountDownLatch latch = exitLatch;
+@@ -642,7 +650,7 @@
+         if (packet.getRequestedState() == EnumConnectionState.LOGIN && (!NetworkRegistry.INSTANCE.isVanillaAccepted(Side.CLIENT) && !packet.hasFMLMarker()))
+         {
+             manager.setConnectionState(EnumConnectionState.LOGIN);
+-            TextComponentString text = new TextComponentString("This server has mods that require FML/Forge to be installed on the client. Contact your server admin for more details.");
++            TextComponentString text = new TextComponentString(ChatColor.translateAlternateColorCodes('&', MagmaConfig.instance.fmlRequiredMessage.getValues())); // Magma
+             Collection<String> modNames = NetworkRegistry.INSTANCE.getRequiredMods(Side.CLIENT);
+             FMLLog.log.info("Disconnecting Player: This server has mods that require FML/Forge to be installed on the client: {}", modNames);
+             manager.sendPacket(new SPacketDisconnect(text));

--- a/patches/net/minecraftforge/fml/common/network/internal/FMLNetworkHandler.java.patch
+++ b/patches/net/minecraftforge/fml/common/network/internal/FMLNetworkHandler.java.patch
@@ -13,11 +13,12 @@
  import net.minecraft.world.World;
  import net.minecraftforge.common.util.FakePlayer;
  import net.minecraftforge.fml.common.FMLCommonHandler;
-@@ -58,6 +61,12 @@
+@@ -58,6 +61,13 @@
  import com.google.gson.JsonArray;
  import com.google.gson.JsonObject;
  import org.apache.commons.lang3.tuple.Pair;
 +import org.bukkit.Bukkit;
++import org.bukkit.ChatColor;
 +import org.bukkit.craftbukkit.v1_12_R1.event.CraftEventFactory;
 +import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftInventory;
 +import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftInventoryView;
@@ -26,7 +27,7 @@
  
  import javax.annotation.Nullable;
  
-@@ -88,6 +97,20 @@
+@@ -88,6 +98,20 @@
              Container remoteGuiContainer = NetworkRegistry.INSTANCE.getRemoteGuiContainer(mc, entityPlayerMP, modGuiId, world, x, y, z);
              if (remoteGuiContainer != null)
              {
@@ -47,7 +48,16 @@
                  entityPlayerMP.getNextWindowId();
                  entityPlayerMP.closeContainer();
                  int windowId = entityPlayerMP.currentWindowId;
-@@ -210,7 +233,7 @@
+@@ -168,7 +192,7 @@
+             }
+             String rejectString = String.join("\n", rejectStrings);
+             FMLLog.log.info("Rejecting connection {}: {}", side, rejectString);
+-            return String.format("Server Mod rejections:\n%s", rejectString);
++            return String.format(ChatColor.translateAlternateColorCodes('&', MagmaConfig.instance.missingModsMessage.getValues()) + "\n%s", rejectString); // Magma
+         }
+     }
+ 
+@@ -210,7 +234,7 @@
      public static void enhanceStatusQuery(JsonObject jsonobject)
      {
          JsonObject fmlData = new JsonObject();

--- a/src/main/java/org/magmafoundation/magma/configuration/MagmaConfig.java
+++ b/src/main/java/org/magmafoundation/magma/configuration/MagmaConfig.java
@@ -73,6 +73,10 @@ public class MagmaConfig extends ConfigBase {
 
     public final StringValue serverBrandType = new StringValue(this, "magma.advanced.server-type", "FML", "Set to FML to show forge icon or BUKKIT to show bukkit icon (FML is default)");
 
+    //=============================Message SETTINGS==============================
+    public final StringValue fmlRequiredMessage = new StringValue(this, "magma.messages.fml.fml-required", "&cThis Server is running Magma. Forge and additional mods are required in order to connect to this server.", "FML required kick message");
+    public final StringValue missingModsMessage = new StringValue(this, "magma.messages.fml.missing-mods", "&cYou are missing the following mods:", "Missing Mods kick message");
+
     private final String HEADER = "This is the main configuration file for Magma.\n" +
         "\n" +
         "Site: https://magmafoundation.org\n" +


### PR DESCRIPTION
You can customize the FML kick messages (no forge installed and missing mods)
![grafik](https://user-images.githubusercontent.com/50475262/102688743-ed11e580-41f8-11eb-8812-3cbec74f97d0.png)

```yml
  messages:
    fml:
      fml-required: '&cThis Server is running Magma. Forge and additional mods are
        required in order to connect to this server.'
      missing-mods: '&cYou are missing the following mods:'
```