### PR TITLE
Fix CraftItemStack to handle ItemBlocks from mods.

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemFactory.java
@@ -139,7 +139,12 @@ public final class CraftItemFactory implements ItemFactory {
         case ENDER_CHEST:
             return new CraftMetaBlockState(meta, material);
         default:
-            return new CraftMetaItem(meta);
+            if (material.getMaterialType() == Material.MaterialType.MOD_BLOCK || material.getMaterialType() == Material.MaterialType.MOD_ITEM) {
+                //MOD_ITEM is also used for blocks as items
+                return new CraftMetaBlockState(meta, material);
+            } else {
+                return new CraftMetaItem(meta);
+            }
         }
     }
 

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemFactory.java
@@ -139,12 +139,10 @@ public final class CraftItemFactory implements ItemFactory {
         case ENDER_CHEST:
             return new CraftMetaBlockState(meta, material);
         default:
-            if (material.getMaterialType() == Material.MaterialType.MOD_BLOCK || material.getMaterialType() == Material.MaterialType.MOD_ITEM) {
-                //MOD_ITEM is also used for blocks as items
+            if (meta instanceof CraftMetaBlockState) {
                 return new CraftMetaBlockState(meta, material);
-            } else {
-                return new CraftMetaItem(meta);
             }
+            return new CraftMetaItem(meta);
         }
     }
 

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
@@ -401,7 +401,6 @@ public final class CraftItemStack extends ItemStack {
                     return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
                 }
 				return new CraftMetaItem(item.getTagCompound());
-            }
         }
     }
 

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.item.Item;
 
+import net.minecraft.item.ItemBlock;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
 import org.apache.commons.lang3.Validate;
@@ -396,7 +397,14 @@ public final class CraftItemStack extends ItemStack {
             case ENDER_CHEST:
                 return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
             default:
-                return new CraftMetaItem(item.getTagCompound());
+            {
+                if (item.item instanceof ItemBlock) {
+                    //We are actually a block
+                    return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
+                } else {
+                    return new CraftMetaItem(item.getTagCompound());
+                }
+            }
         }
     }
 

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftItemStack.java
@@ -397,13 +397,10 @@ public final class CraftItemStack extends ItemStack {
             case ENDER_CHEST:
                 return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
             default:
-            {
                 if (item.item instanceof ItemBlock) {
-                    //We are actually a block
                     return new CraftMetaBlockState(item.getTagCompound(), CraftMagicNumbers.getMaterial(item.getItem()));
-                } else {
-                    return new CraftMetaItem(item.getTagCompound());
                 }
+				return new CraftMetaItem(item.getTagCompound());
             }
         }
     }

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaBlockState.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaBlockState.java
@@ -211,12 +211,10 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
             case ENDER_CHEST:
                 return true;
         }
-        if (material.getMaterialType() == Material.MaterialType.MOD_BLOCK || material.getMaterialType() == Material.MaterialType.MOD_ITEM) {
-            //MOD_ITEM is also used for blocks as items
+        if (material.getMaterialType() == Material.MaterialType.MOD_ITEM) {
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     @Override

--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaBlockState.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/inventory/CraftMetaBlockState.java
@@ -211,7 +211,12 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
             case ENDER_CHEST:
                 return true;
         }
-        return false;
+        if (material.getMaterialType() == Material.MaterialType.MOD_BLOCK || material.getMaterialType() == Material.MaterialType.MOD_ITEM) {
+            //MOD_ITEM is also used for blocks as items
+            return true;
+        } else {
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently, the block entity tag is stripped from ItemBlocks in mods as they are not being recognised correctly.

This fixes MrCrayfish's Vehicle mod which was having the block entity tag stripped due to not being handled as a CraftMetaBlockState, and causing vehicles to be unplacable via all means.

I've tested the pre-cleanup version of the change for a few weeks found no issues. post-cleanup version has been tested for a few hours and no issues have been found.