### PR TITLE
Fix Shield #375

### DIFF
--- a/patches/net/minecraft/entity/EntityLivingBase.java.patch
+++ b/patches/net/minecraft/entity/EntityLivingBase.java.patch
@@ -441,7 +441,7 @@
 +                boolean flag = amount > 0.0F && this.canBlockDamageSource(source); // Copied from below
  
 -                if (amount > 0.0F && this.canBlockDamageSource(source))
-+                // CraftBukkit - Moved into damageEntity0(DamageSource, float)
++                // CraftBukkit - Moved into damageEntity_CB(DamageSource, float)
 +                if (false && amount > 0.0F && this.canBlockDamageSource(source))
                  {
                      this.damageShield(amount);
@@ -705,12 +705,12 @@
          else
          {
 -            if (this.isPotionActive(MobEffects.RESISTANCE) && source != DamageSource.OUT_OF_WORLD)
-+            // CraftBukkit - Moved to damageEntity0(DamageSource, float)
++            // CraftBukkit - Moved to damageEntity_CB(DamageSource, float)
 +            if (false && this.isPotionActive(MobEffects.RESISTANCE) && source != DamageSource.OUT_OF_WORLD)
              {
                  int i = (this.getActivePotionEffect(MobEffects.RESISTANCE).getAmplifier() + 1) * 5;
                  int j = 25 - i;
-@@ -1405,25 +1592,167 @@
+@@ -1405,25 +1592,164 @@
  
      protected void damageEntity(DamageSource damageSrc, float damageAmount)
      {
@@ -839,9 +839,6 @@
 +                } else {
 +                    this.damageArmor(armorDamage);
 +                }
-+
-+                // Thermos AVOID DAMAGE if armor nullifies it (CraftBukkit failed to include this, this is why TFC bug happened)
-+                if (armorDamage <= 0) return true;
 +            }
 +
 +            // Apply blocking code // PAIL: steal from above
@@ -894,7 +891,7 @@
      }
  
      public CombatTracker getCombatTracker()
-@@ -1605,6 +1934,7 @@
+@@ -1605,6 +1931,7 @@
          if (this.attributeMap == null)
          {
              this.attributeMap = new AttributeMap();
@@ -902,7 +899,7 @@
          }
  
          return this.attributeMap;
-@@ -1685,11 +2015,13 @@
+@@ -1685,11 +2012,13 @@
          }
      }
  
@@ -916,7 +913,7 @@
      protected float getSoundPitch()
      {
          return this.isChild() ? (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.5F : (this.rand.nextFloat() - this.rand.nextFloat()) * 0.2F + 1.0F;
-@@ -1900,7 +2232,8 @@
+@@ -1900,7 +2229,8 @@
  
                          if (this.onGround && !this.world.isRemote)
                          {
@@ -926,7 +923,7 @@
                          }
                      }
                      else
-@@ -2345,7 +2678,6 @@
+@@ -2345,7 +2675,6 @@
          }
  
          this.world.profiler.startSection("ai");
@@ -934,7 +931,7 @@
          if (this.isMovementBlocked())
          {
              this.isJumping = false;
-@@ -2426,6 +2758,7 @@
+@@ -2426,6 +2755,7 @@
  
          if (!this.world.isRemote)
          {
@@ -942,7 +939,7 @@
              this.setFlag(7, flag);
          }
      }
-@@ -2560,12 +2893,12 @@
+@@ -2560,12 +2890,12 @@
  
      public boolean canBeCollidedWith()
      {
@@ -957,7 +954,7 @@
      }
  
      protected void markVelocityChanged()
-@@ -2629,7 +2962,7 @@
+@@ -2629,7 +2959,7 @@
          {
              PotionEffect effect = iterator.next();
  
@@ -966,7 +963,7 @@
              {
                  onFinishedPotionEffect(effect);
                  iterator.remove();
-@@ -2667,7 +3000,8 @@
+@@ -2667,7 +2997,8 @@
          if (this.isHandActive())
          {
              ItemStack itemstack = this.getHeldItem(this.getActiveHand());
@@ -976,7 +973,7 @@
  
              if (itemstack == this.activeItemStack)
              {
-@@ -2785,8 +3119,25 @@
+@@ -2785,8 +3116,25 @@
          if (!this.activeItemStack.isEmpty() && this.isHandActive())
          {
              this.updateItemUse(this.activeItemStack, 16);
@@ -1004,7 +1001,7 @@
              itemstack = net.minecraftforge.event.ForgeEventFactory.onItemUseFinish(this, activeItemStackCopy, getItemInUseCount(), itemstack);
              this.setHeldItem(this.getActiveHand(), itemstack);
              this.resetActiveHand();
-@@ -2897,12 +3248,17 @@
+@@ -2897,12 +3245,17 @@
  
              if (flag1)
              {
@@ -1027,7 +1024,7 @@
              }
          }
  
-@@ -2936,6 +3292,11 @@
+@@ -2936,6 +3289,11 @@
          }
      }
  
@@ -1039,7 +1036,7 @@
      public boolean canBeHitWithPotion()
      {
          return true;
-@@ -2949,7 +3310,7 @@
+@@ -2949,7 +3307,7 @@
      @SuppressWarnings("unchecked")
      @Override
      @Nullable
@@ -1048,7 +1045,7 @@
      {
          if (capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY)
          {
-@@ -2961,7 +3322,7 @@
+@@ -2961,7 +3319,7 @@
      }
  
      @Override
@@ -1057,7 +1054,7 @@
      {
          return capability == net.minecraftforge.items.CapabilityItemHandler.ITEM_HANDLER_CAPABILITY || super.hasCapability(capability, facing);
      }
-@@ -2975,7 +3336,7 @@
+@@ -2975,7 +3333,7 @@
      public void setPartying(BlockPos pos, boolean p_191987_2_)
      {
      }


### PR DESCRIPTION
This is related to the issues reported about the Shield like #375.

Currently the code of magma include a patch for a TFC bug, but this cause bugs to the shields like:

- Shields not take damage
- Shields not disabled if the attacker use Axe
- The player with shield have anormal knockback

This patch fix this issues.