### PR TITLE
Fixes CraftServer crash for certain commands

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/CraftServer.java
@@ -381,7 +381,7 @@ public final class CraftServer implements Server {
             if (!(cmd instanceof CommandBase)) continue;
             if (console.getCommandManager().getCommandMod().containsValue(cmd))
                 continue;
-            VanillaCommandWrapper wrapper = new VanillaCommandWrapper((CommandBase) cmd, I18n.translateToLocal(cmd.getUsage(null)));
+            VanillaCommandWrapper wrapper = new VanillaCommandWrapper((CommandBase) cmd, I18n.translateToLocal(cmd.getUsage(FMLCommonHandler.instance().getMinecraftServerInstance())));
             if (org.spigotmc.SpigotConfig.replaceCommands.contains(wrapper.getName())) {
                 if (first) {
                     commandMap.register("minecraft", wrapper);


### PR DESCRIPTION
Certain Forge mods will crash on boot if null command sender is not expected.

NMS doesn't pass in a null sender at any time nor is the param annotated as nullable this ensures max compatibility especially with languages such as Kotlin.