### PR TITLE
Resolved FakePlayer NPE

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/v1_12_R1/event/CraftEventFactory.java
+++ b/src/main/java/org/bukkit/craftbukkit/v1_12_R1/event/CraftEventFactory.java
@@ -1212,13 +1212,12 @@ public class CraftEventFactory {
     }
 
     // Cauldron start
-    public static BlockBreakEvent callBlockBreakEvent(net.minecraft.world.World world, BlockPos pos, IBlockState iBlockState, net.minecraft.entity.player.EntityPlayerMP player) {
+    public static BlockBreakEvent callBlockBreakEvent(net.minecraft.world.World world, BlockPos pos, IBlockState iBlockState, EntityPlayerMP player) {
         org.bukkit.block.Block bukkitBlock = world.getWorld().getBlockAt(pos.getX(), pos.getY(), pos.getZ());
-        org.bukkit.event.block.BlockBreakEvent blockBreakEvent = new org.bukkit.event.block.BlockBreakEvent(bukkitBlock, Bukkit.getPlayer(player.getUniqueID()));
-        EntityPlayerMP playermp = (EntityPlayerMP) player;
+        org.bukkit.event.block.BlockBreakEvent blockBreakEvent = new org.bukkit.event.block.BlockBreakEvent(bukkitBlock, player.getBukkitEntity());
         net.minecraft.block.Block block = iBlockState.getBlock();
-        if (!(playermp instanceof FakePlayer)) {
-            boolean isSwordNoBreak = playermp.interactionManager.getGameType().isCreative() && !playermp.getHeldItemMainhand().isEmpty() && playermp.getHeldItemMainhand().getItem() instanceof ItemSword;
+        if (!(player instanceof FakePlayer)) {
+            boolean isSwordNoBreak = player.interactionManager.getGameType().isCreative() && !player.getHeldItemMainhand().isEmpty() && player.getHeldItemMainhand().getItem() instanceof ItemSword;
             if (!isSwordNoBreak) {
                 int exp = 0;
                 if (!(block == null || !player.canHarvestBlock(block.getDefaultState()) || block.canSilkHarvest(world, pos, block.getBlockState().getBaseState(), player) && EnchantmentHelper.getEnchantmentLevel(Enchantments.SILK_TOUCH, player.getHeldItemMainhand()) > 0)) {


### PR DESCRIPTION
Usually FakePlayers are not registered anywhere, since it is null object. There is no sense to re-search player instance by UUIID.
It is also faster.

Will close #465.